### PR TITLE
Add support for csp build of riot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 sudo: false
 
 install:
-  - npm i && npm install riot
+  - npm install riot && npm i
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ module.exports = {
         loader: 'riot-tag-loader',
         query: {
           hot: false, // set it to true if you are using hmr
+          csp: false, // set it to true if you want to use the CSP build of riot
           // add here all the other riot-compiler options riotjs.com/guide/compiler/
           // template: 'pug' for example
         }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function(source) {
   if (query.hot) hotReloadCode = hotReload(tags)
 
   return `
-    var riot = require('riot')
+    var riot = require(${ query.csp ? "'riot/riot.csp'" : "'riot'"})
     ${ code }
     ${ hotReloadCode }
   `


### PR DESCRIPTION
Solves [Issue no 8](https://github.com/riot/tag-loader/issues/8)

Building chrome extensions requires the csp build of the riot library and couldn't figure out a way to use the `riot.csp.js` instead of `riot.js` with this loader without making changes to it. The user can now switch to the csp build if he requires it by passing a simple `query` param. 