### PR TITLE
Fixing tests and loader utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,10 +19,10 @@ function hotReload(tags) {
 
 
 module.exports = function(source) {
-  const query = typeof this.query === 'string' ? loaderUtils.parseQuery(this.query) : this.query
+  const options = loaderUtils.getOptions(this) || {}
   const {code, map} = riot.compile(
     source,
-    Object.assign(query, { sourcemap: true }),
+    Object.assign(options, { sourcemap: true }),
     this.resourcePath
   )
 
@@ -34,7 +34,7 @@ module.exports = function(source) {
   })
 
   if (this.cacheable) this.cacheable()
-  if (query.hot) hotReloadCode = hotReload(tags)
+  if (options.hot) hotReloadCode = hotReload(tags)
 
   this.callback(null, `
     var riot = require('riot')

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^4.13.1",
     "eslint-config-riot": "^1.0.0",
     "mocha": "^4.0.1",
+    "riot": "^3.0.7",
     "webpack": "^3.10.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,7 @@ describe('riot-tag-loader unit test', () => {
     compile().then(content => {
       assert.equal(content, readFile('bundle-normal.js'))
       done()
-    })
+    }).catch(error => console.error(error))
   })
 
   it('riot loader hot reload options', (done) => {
@@ -38,6 +38,6 @@ describe('riot-tag-loader unit test', () => {
     }).then(content => {
       assert.equal(content, readFile('bundle-hot.js'))
       done()
-    })
+    }).catch(error => console.error(error))
   })
 })


### PR DESCRIPTION
- fixing a few issues I ran into when trying to run unit tests
- using `loaderUtils.getOptions` instead of `loaderUtils.parseQuery`