### PR TITLE
#13 loader.query is not defined in webpack.config.js, cause error (Cannot convert undefined or null to object)

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function(source) {
   const tags = []
 
   // parse the user query
-  const query = getOptions(this)
+  const query = getOptions(this) || {}
 
   // normalise the query object in case of question marks
   const opts = Object.keys(query).reduce(function(acc, key) {

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ function readFile(file) {
   return normalize(fs.readFileSync(path.join(EXPECT, file), 'utf8'))
 }
 
-function compile(opts = {}) {
+function compile(opts) {
   webpackConfig.module.loaders[0].query = opts
   const compiler = webpack(webpackConfig)
   return new Promise(resolve => {
@@ -25,8 +25,15 @@ function compile(opts = {}) {
 }
 
 describe('riot-tag-loader unit test', () => {
-  it('riot loader default options', (done) => {
-    compile().then(content => {
+  it('riot loader undefined options', (done) => {
+    compile(undefined).then(content => {
+      assert.equal(content, readFile('bundle-normal.js'))
+      done()
+    })
+  })
+
+  it('riot loader empty options', (done) => {
+    compile({}).then(content => {
       assert.equal(content, readFile('bundle-normal.js'))
       done()
     })
@@ -54,4 +61,5 @@ describe('riot-tag-loader unit test', () => {
       done()
     })
   })
+
 })

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -15,8 +15,7 @@ module.exports = {
     loaders: [
       {
         test: /\.tag$/,
-        loader: 'riot-tag-loader',
-        query: {}
+        loader: 'riot-tag-loader'
       }
     ]
   },


### PR DESCRIPTION
If loader.query is not defined in webpack.config.js, getOptions is return null and Object.keys(query) is cause error.

function compile() in test/index.js, is use default option ({}), not cause this probrem.

I'm fix this pattern and write test case.

* test environment : node --version -> v8.9.0

