### PR TITLE
commonjs & modular option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ import 'riot-hot-reload'
 // riot will have now a new riot.reload method!!
 ```
 
+## Modular usage
+
+By default the loader prepends `var riot = require('riot')` to the compiled file to support CommonJS. If you need to turn this off just set the option `commonjs: false`.
+
+Alternatively you can use the option `modular: true`. This will wrap the compiled code in a function and includes AMD and CommonJS support if possible. The output will then look like this:
+
+```js
+(function(tagger) {
+  if (typeof define === 'function' && define.amd) {
+    define(['riot'], function(riot) { tagger(riot); });
+  } else if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+    tagger(require('riot'));
+  } else {
+    tagger(window.riot);
+  }
+})(function(riot) {
+
+  // compiled tag code here
+
+});
+```
+
 ## Examples
 
 Please check [this simple example](https://github.com/riot/examples/tree/gh-pages/webpack) to see how it's easy to configure webpack with riot

--- a/index.js
+++ b/index.js
@@ -64,12 +64,12 @@ module.exports = function(source) {
 
   // Prepend require()
   if (opts.commonjs !== false) {
-    output = `\nvar riot = require('riot');${ output }`;
+    output = `\nvar riot = require('riot');${ output }`
   }
 
   // Support modular usage
   if (opts.modular) {
-    output = `\n(function(tagger) {\n  if (typeof define === 'function' && define.amd) {\n    define(['riot'], function(riot) { tagger(riot); });\n  } else if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {\n    tagger(require('riot'));\n  } else {\n    tagger(window.riot);\n  }\n})(function(riot) {${ output }\r});`;
+    output = `\n(function(tagger) {\n  if (typeof define === 'function' && define.amd) {\n    define(['riot'], function(riot) { tagger(riot); });\n  } else if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {\n    tagger(require('riot'));\n  } else {\n    tagger(window.riot);\n  }\n})(function(riot) {${ output }\r});`
   }
 
   // cache this module

--- a/index.js
+++ b/index.js
@@ -54,12 +54,23 @@ module.exports = function(source) {
     tags.push(match)
   })
 
+  // Prepend code 
+
   // generate the output code
-  const output = `
-    var riot = require('riot')
+  let output = `
     ${ code }
     ${ opts.hot ? hotReload(tags) : '' }
   `
+
+  // Prepend require()
+  if (opts.commonjs !== false) {
+    output = `\nvar riot = require('riot');${ output }`;
+  }
+
+  // Support modular usage
+  if (opts.modular) {
+    output = `\n(function(tagger) {\n  if (typeof define === 'function' && define.amd) {\n    define(['riot'], function(riot) { tagger(riot); });\n  } else if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {\n    tagger(require('riot'));\n  } else {\n    tagger(window.riot);\n  }\n})(function(riot) {${ output }\r});`;
+  }
 
   // cache this module
   if (this.cacheable) this.cacheable()


### PR DESCRIPTION
This PR fixes https://github.com/riot/tag-loader/issues/19 by adding the new option `commonjs` which provides the possibility to disable prepending `var riot = require('riot')` to the compiled code.

The option is default true so this update does not break any existing project.
To disable it you have to explicitly set `commonjs: false` in the loader options.

In the course of this PR I've added another option called `modular` which acts similar to the custom option of the [gulp-riot](https://github.com/e-jigsaw/gulp-riot) plugin.
If true the compiled code gets wrapped in a function (keeps global scope clean) and supports AMD & CommonJS if possible. The result will look like this:

```javascript
(function(tagger) {
  if (typeof define === 'function' && define.amd) {
    define(['riot'], function(riot) { tagger(riot); });
  } else if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
    tagger(require('riot'));
  } else {
    tagger(window.riot);
  }
})(function(riot) {

  // compiled tag code here

});
```

So the bottom line is two new options without breaking any existing project.

@GianlucaGuarini would you review and let me know if this is ok to merge?

